### PR TITLE
Corrected data attribute names

### DIFF
--- a/Module - Building the Contacts App GUI/MVCContactsApp/Views/Contacts/Index.cshtml
+++ b/Module - Building the Contacts App GUI/MVCContactsApp/Views/Contacts/Index.cshtml
@@ -69,7 +69,7 @@
     </div>
 </div>
 
-<div id="deleteModal" class="modal fade" data-bs-backdrop="static" data-bs-keyboard="false">
+<div id="deleteModal" class="modal fade" data-backdrop="static" data-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Two data attributes defined in the Bootstrap modal had names based on the Bootstrap 5 convention, but the project has Bootstrap 4 installed.  This was allowing the modal to be closed by clicking outside of it which is unwanted behavior.  Changed the data attribute names to the Bootstrap 4 convention to resolve the issue.